### PR TITLE
Specify correct author_id when storing blog post

### DIFF
--- a/server.js
+++ b/server.js
@@ -190,7 +190,7 @@ app.post('/posts', (req, res) => {
           .create({
             title: req.body.title,
             content: req.body.content,
-            author: req.body.id
+            author: req.body.author_id
           })
           .then(blogPost => res.status(201).json({
               id: blogPost.id,


### PR DESCRIPTION
Creating blog posts will fail since it doesn't properly relate the author to the blog post.  This fixes that issue.